### PR TITLE
Improve padding and width for Notifications

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -46,7 +46,7 @@ export const NotificationBase = styled.aside`
   align-items: flex-start;
   font-size: var(--fontSizes-tiny);
   font-weight: 600;
-  padding: var(--space-1) var(--space-1);
+  padding: var(--space-2) var(--space-2);
   border-radius: var(--rounded);
   animation-duration: 0.1s;
   animation-iteration-count: 1;
@@ -171,7 +171,8 @@ const NotificationsContainer = styled.div`
   z-index: var(--z-notifications);
   top: 0;
   right: 0;
-  width: 18rem;
+  max-width: 18rem;
+  min-width: 12rem;
   padding: var(--space-1);
 `;
 


### PR DESCRIPTION
Per issue here, we want to add some more padding and make the width of notifications more flexible. Screenshots of the changes are in that issue.
https://app.clubhouse.io/glitch/story/8589/change-default-padding-for-notifications#activity-8614