### PR TITLE
Add ability to remove notifications

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -261,32 +261,48 @@ const UploadNotification = ({ onClose }) => {
 };
 
 const Content = () => {
-  const { createNotification, createErrorNotification } = useNotifications();
+  const { createNotification, createErrorNotification, removeNotification } = useNotifications();
+  const [lastNotificationId, setLastNotificationId] = React.useState(null);
 
   return (
     <>
-      <Button onClick={() => createNotification(UploadNotification)}>Create Notification</Button>
+      <Button
+        onClick={() => {
+          const notification = createNotification(UploadNotification);
+          setLastNotificationId(notification.id);
+        }}
+      >
+        Create Notification
+      </Button>
       &nbsp;
       <Button
-        onClick={() =>
-          createNotification((props) => (
+        onClick={() => {
+          const notification = createNotification((props) => (
             <Notification variant="success" {...props} message="Added power-passenger to collection linen-collection">
               <p style={{ marginTop: 0 }}>Added power-passenger to collection linen-collection</p>
               <Button as="a" variant="secondary" size="tiny" href="https://glitch.com/@modernserf/linen-collection" rel="noopener noreferrer">
                 Take me there
               </Button>
             </Notification>
-          ))
-        }
+          ));
+          setLastNotificationId(notification.id);
+        }}
       >
         Create Success Notification
       </Button>
       &nbsp;
-      <Button onClick={() => createErrorNotification()}>Create Error Notification</Button>
+      <Button
+        onClick={() => {
+          const notification = createErrorNotification();
+          setLastNotificationId(notification.id);
+        }}
+      >
+        Create Error Notification
+      </Button>
       &nbsp;
       <Button
-        onClick={() =>
-          createNotification((props) => (
+        onClick={() => {
+          const notification = createNotification((props) => (
             <Notification variant="onboarding" {...props} message="Create an account to keep this project and edit it anywhere.">
               <p style={{ marginTop: 0 }}>
                 <strong>Create an account</strong> to keep this project, and edit it anywhere.
@@ -299,10 +315,20 @@ const Content = () => {
                 Hide
               </Button>
             </Notification>
-          ))
-        }
+          ));
+          setLastNotificationId(notification.id);
+        }}
       >
         Create Onboarding Notification
+      </Button>
+      <Button
+        onClick={() => {
+          removeNotification(lastNotificationId);
+          setLastNotificationId(null);
+        }}
+        disabled={!lastNotificationId}
+      >
+        Remove Last Notification
       </Button>
     </>
   );

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -186,13 +186,14 @@ export const NotificationsProvider = ({ children, ...props }) => {
     const createNotification = (Component) => {
       const notification = { id: uniqueID('notification'), Component };
       setNotifications((prevNotifications) => [...prevNotifications, notification]);
+      return notification;
     };
 
     const createErrorNotification = (message = 'Something went wrong. Try refreshing?') => {
-      createNotification((props) => <Notification variant="error" timeout={2500} live="polite" message={message} {...props} />);
+      return createNotification((props) => <Notification variant="error" timeout={2500} live="polite" message={message} {...props} />);
     };
 
-    return { createNotification, createErrorNotification };
+    return { createNotification, createErrorNotification, removeNotification };
   }, []);
 
   return (


### PR DESCRIPTION
This PR puts `removeNotification` into context so it can be used inside the NotificationProvider, and modifies the `createNotification` function to return the notification (which includes its ID), such that the id can then later be used to remove the notification.

Demo here:
https://glitch.com/edit/#!/equatorial-mushroom-a3p4w27vxl?path=lib/notification.js:1:0

I added a button "Remove Last Notification" into the Notification Story to demonstrate how to remove the last notification that was added.
