### PR TITLE
Added persistent state for notifications and made default timeout 2.5s

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -55,7 +55,7 @@ export const NotificationBase = styled.aside`
   animation-timing-function: ease-out;
 
   ${({ variant }) => variants[variant]}
-  ${({ closing, timeout }) => {
+  ${({ closing, timeout, persistent }) => {
     if (closing) {
       return css`
         animation-name: ${closingAnimation};
@@ -66,7 +66,7 @@ export const NotificationBase = styled.aside`
         }
       `;
     }
-    if (timeout > 0) {
+    if (!persistent) {
       return css`
         animation-name: ${closingAnimation};
         animation-delay: ${timeout}ms;
@@ -88,7 +88,7 @@ const NotificationContent = styled.div`
   margin-right: var(--space-1);
 `;
 
-export const Notification = ({ message, live, children, variant, timeout, onClose, ...props }) => {
+export const Notification = ({ message, live, children, variant, timeout, onClose, persistent, ...props }) => {
   const ref = React.useRef();
   const [closing, setClosing] = React.useState(false);
 
@@ -105,6 +105,7 @@ export const Notification = ({ message, live, children, variant, timeout, onClos
       closing={closing}
       timeout={timeout}
       onAnimationEnd={handleAnimationEnd}
+      persistent={persistent}
       {...props}
     >
       <NotificationContent>{children || message}</NotificationContent>
@@ -124,12 +125,13 @@ Notification.propTypes = {
   variant: PropTypes.oneOf(Object.keys(variants)),
   timeout: PropTypes.number,
   onClose: PropTypes.func,
+  persistent: PropTypes.bool,
 };
 
 Notification.defaultProps = {
   variant: 'notice',
   live: 'polite',
-  timeout: 0,
+  timeout: 2500,
 };
 
 export const StoryNotification = () => (
@@ -145,11 +147,15 @@ export const StoryNotification = () => (
       <Prop name="variant">The style of notification: "notice", "success", "error", "onboarding" (default "notice").</Prop>
       <Prop name="timeout">
         The time in milliseconds before the notification automatically fades out and calls its "onClose" prop. If no value is provided, the
-        notification will not automatically close.
+        notification will close after the default period specified in the default props.
       </Prop>
       <Prop name="onClose">
         A callback function, called when the close button is clicked or the notification times out. This props is provided by the{' '}
         <code>createNotification</code> callback. If no value is provided, the notification will not render a close button.
+      </Prop>
+      <Prop name="persistent">
+        A boolean value. If true, any timeout value is ignored and the Notification will remain until removed either programmatically or by a 
+        user action. If no value is provided, the Notification will be removed after the timeout period.
       </Prop>
     </PropsDefinition>
     <p></p>
@@ -190,7 +196,7 @@ export const NotificationsProvider = ({ children, ...props }) => {
     };
 
     const createErrorNotification = (message = 'Something went wrong. Try refreshing?') => {
-      return createNotification((props) => <Notification variant="error" timeout={2500} live="polite" message={message} {...props} />);
+      return createNotification((props) => <Notification variant="error" live="polite" message={message} {...props} />);
     };
 
     return { createNotification, createErrorNotification, removeNotification };
@@ -251,7 +257,7 @@ const UploadNotification = ({ onClose }) => {
   }
 
   return (
-    <Notification timeout={2500} onClose={onClose} message="Uploaded!">
+    <Notification onClose={onClose} message="Uploaded!">
       <Progress value={value} max={100} style={{ display: 'inline-block', width: '4rem' }}>
         {value}%
       </Progress>
@@ -278,7 +284,7 @@ const Content = () => {
       <Button
         onClick={() => {
           const notification = createNotification((props) => (
-            <Notification variant="success" {...props} message="Added power-passenger to collection linen-collection">
+            <Notification variant="success" {...props} persistent message="Added power-passenger to collection linen-collection">
               <p style={{ marginTop: 0 }}>Added power-passenger to collection linen-collection</p>
               <Button as="a" variant="secondary" size="tiny" href="https://glitch.com/@modernserf/linen-collection" rel="noopener noreferrer">
                 Take me there
@@ -303,7 +309,7 @@ const Content = () => {
       <Button
         onClick={() => {
           const notification = createNotification((props) => (
-            <Notification variant="onboarding" {...props} message="Create an account to keep this project and edit it anywhere.">
+            <Notification variant="onboarding" persistent {...props} message="Create an account to keep this project and edit it anywhere.">
               <p style={{ marginTop: 0 }}>
                 <strong>Create an account</strong> to keep this project, and edit it anywhere.
               </p>


### PR DESCRIPTION
In general, the notifications that we show up disappear after 2.5s. This makes that the default, and adds a persistent state in the cases where we don't want them to disappear.

Worth noting that in the Community site, there's an inline Notification that is usually persistent. I think we should handle this case by creating a separate InlineNotification component which is used outside of NotificationsProvider, that sets the Notification to persistent.

![Screenshot 2020-02-05 at 10 52 08 AM](https://user-images.githubusercontent.com/9853740/73857907-97f9fa80-4805-11ea-9265-052c87757522.png)
