### PR TITLE
Make external icon into an svg so it can go dark-mode 

### DIFF
--- a/lib/icon.js
+++ b/lib/icon.js
@@ -56,6 +56,11 @@ const svgs = {
       <polygon fill="currentColor" points="8.5,3 8.5,9 4.5,6" />
     </SVGBase>
   ),
+  external: (props) => (
+    <SVGBase width="12" height="12" fill="none" {...props}>
+        <path fillRule="evenodd" clipRule="evenodd" d="M6 1.2V0h6v6h-1.2V2.046l-3.6 3.6V6.6v-.954L3.846 9 3 8.154 7.554 3.6H5.4v1.2H1.2v6h6V6.6h1.2V12H0V3.6h7.554l2.4-2.4H6z" fill="currentColor"/>
+    </SVGBase>
+  ),
   eye: (props) => (
     <SVGBase viewBox="0 0 19 14" {...props}>
       <path
@@ -188,7 +193,6 @@ const icons = {
   dogFace: 'https://cdn.glitch.com/e7e23ba6-c0ec-4a5a-8dcf-b6f61984cea8%2Fdog_face.png?v=1568142112319',
   earthAsia: 'https://cdn.glitch.com/d7f4f279-e13b-4330-8422-00b2d9211424%2Fearth-asia.png',
   email: 'https://cdn.glitch.com/e7e23ba6-c0ec-4a5a-8dcf-b6f61984cea8%2Femail.png?v=1568142112421',
-  external: 'https://cdn.glitch.com/d7f4f279-e13b-4330-8422-00b2d9211424%2Ficon_external.png?v=1584034396451',
   eyeglasses: 'https://cdn.glitch.com/d7f4f279-e13b-4330-8422-00b2d9211424%2Feyeglasses.png?v=1578491957263',
   eyes: 'https://cdn.glitch.com/e7e23ba6-c0ec-4a5a-8dcf-b6f61984cea8%2Feyes.png?v=1568142112532',
   facebook: 'https://cdn.glitch.com/e7e23ba6-c0ec-4a5a-8dcf-b6f61984cea8%2Ffacebook.png?v=1568142112883',


### PR DESCRIPTION
https://bottlenose-glowing-thimbleberry.glitch.me/#StoryIcon 

No change to the component contract: `<Icon icon="external" />` will do the same thing, but will respond to color changes the way the other SVG icons do. 

![image](https://user-images.githubusercontent.com/4480480/76783471-e93fc700-677f-11ea-992e-4711bdc0e9e2.png)
