### PR TITLE
fix file watcher

### DIFF
--- a/server/rollup.js
+++ b/server/rollup.js
@@ -1,5 +1,5 @@
+const path = require('path');
 const rollup = require('rollup');
-
 const rollupConfig = require('../rollup.config');
 const { watchFiles } = require('./watch');
 
@@ -13,11 +13,16 @@ async function build({ filePath, bundleOptions, additionalConfig = {} }) {
   const {
     output: [{ code, modules }],
   } = await bundle.generate(bundleOptions);
+
+  const fileToWatchPath = path.resolve(__dirname, '../lib');
+
+  const filesToWatch = Object.keys(modules)
+    .filter((fileName) => fileName.startsWith(fileToWatchPath))
+    .sort();
+
   return {
     code,
-    filesToWatch: Object.keys(modules)
-      .filter((fileName) => fileName.startsWith(__dirname))
-      .sort(),
+    filesToWatch,
   };
 }
 

--- a/watch.json
+++ b/watch.json
@@ -3,6 +3,7 @@
     "include": ["^package\\.json$", "^\\.env$"]
   },
   "restart": {
+    "exclude": ["^lib/"],
     "include": ["\\.js$", "\\.json"]
   },
   "throttle": 1000


### PR DESCRIPTION
- Fix the file watcher for the dev environment so that the bundle rebuilds when files change
- Update watch.json to let the file watcher rebuild instead of restarting on changes
- no changes to bundle code, so no version bump