### PR TITLE
Update update script be smarter

### DIFF
--- a/sh/update.sh
+++ b/sh/update.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Updates the existing local and origin branches corresponding to the remix
+# pass an argument if you want to pull a different branch name than the current branch you're on
+# no argument needed to update against the branch name of the current branch
 
-git checkout $1
-git pull $1 master
-git push origin $1
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+branchToUse="$1" && [[  -z "$1" ]]  && branchToUse="$(git rev-parse --abbrev-ref HEAD)"
+
+git checkout $branchToUse
+git pull $branchToUse master
+git push origin $branchToUse

--- a/sh/update.sh
+++ b/sh/update.sh
@@ -3,8 +3,7 @@
 # pass an argument if you want to pull a different branch name than the current branch you're on
 # no argument needed to update against the branch name of the current branch
 
-current_branch="$(git rev-parse --abbrev-ref HEAD)"
-
+# branch to use is the first argument, but if the first argument was not passed, use the current git branch
 branchToUse="$1" && [[  -z "$1" ]]  && branchToUse="$(git rev-parse --abbrev-ref HEAD)"
 
 git checkout $branchToUse


### PR DESCRIPTION
## Previous behavior: 
- must always run `./sh/update.sh branch_and_remix_name`

## New behavior: 
- can run `./sh/update.sh branch_and_remix_name`
- can also just run `./sh/update.sh`, and the branch/remix used will be the current working branch from git. 

## examples
1. I'm on branch resisted-prickly-sand, I want to update from glitch.com/~resisted-prickly-sand and the branch resisted-prickly-sand on github
![image](https://user-images.githubusercontent.com/4480480/77106413-088f5c00-69ed-11ea-9157-e26f649cdb9d.png)

2. I'm on branch `test`, I want to update from glitch.com/~rich-red and to the branch rich-red on github. 
![image](https://user-images.githubusercontent.com/4480480/77106544-442a2600-69ed-11ea-86c8-d4d696dd5bdc.png)

