### PR TITLE
Circle CI changes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+jobs:
+  lint_and_build:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - run:
+          name: npm-install
+          command: npm ci --production=false
+      - run:
+          name: eslint
+          command: npm run lint
+      - run:
+          name: build
+          command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,3 +14,8 @@ jobs:
       - run:
           name: build
           command: npm run rollup
+workflows:
+  version: 2.1
+  regular-workflow:
+    jobs:
+      - lint_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,4 @@ jobs:
           command: npm run lint
       - run:
           name: build
-          command: npm run build
+          command: npm run rollup

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "changelog": "node server/changelog.js",
     "check-changelog": "node server/check-changelog.js",
     "start": "npm run serve",
-    "test": "npm run rollup && npm run lint",
+    "test": "npm run lint",
     "prepublishOnly": "npm test && npm run rollup",
     "postversion": "npm run changelog"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "changelog": "node server/changelog.js",
     "check-changelog": "node server/check-changelog.js",
     "start": "npm run serve",
-    "test": "npm run lint",
+    "test": "npm run rollup && npm run lint",
     "prepublishOnly": "npm test && npm run rollup",
     "postversion": "npm run changelog"
   },


### PR DESCRIPTION
Also do a build as part of `test`. Circle CI will automatically (with no config file defined, so by default) run `npm run test` so we can just jam more stuff we want to test in there for now, until it becomes necessary to have a real Circle CI config of our own.  