### PR TITLE
fix defaultSrc behavior if src is null

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.7] - 2020-04-29
+### Changed
+- `lib/avatar.js`: fix Avatar defaultSrc behavior when src is null / undefined
+
 ## [0.14.6] - 2020-04-23
 Add EditableProjectDomain and a back arrow icon
 

--- a/lib/avatar.js
+++ b/lib/avatar.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { CodeExample, PropsDefinition, Prop } from './story-utils';
+import { TextInput } from './text-input';
 
 const Image = React.forwardRef(({ src, defaultSrc, alt, ...props }, ref) => {
   const [activeSrc, setActiveSrc] = React.useState(src || defaultSrc);
   React.useEffect(() => {
-    setActiveSrc(src);
-  }, [src]);
+    setActiveSrc(src || defaultSrc);
+  }, [src, defaultSrc]);
 
   const onError = () => {
     if (defaultSrc && activeSrc !== defaultSrc) {
@@ -117,3 +118,23 @@ export const StoryAvatar_variants = () => (
     </div>
   </Flex>
 );
+
+const AvatarContainer = styled.div`
+  width: 100px;
+  margin: var(--space-2);
+`;
+
+export const StoryAvatar_defaultSrc = () => {
+  const [src, setSrc] = React.useState(null);
+  return (
+    <>
+      <p>If src is not present or the image at the URL does not load, Avatar shows the image at defaultSrc instead.</p>
+      <div>
+        <TextInput value={src} onChange={setSrc} placeholder="img src" label="img src" />
+      </div>
+      <AvatarContainer>
+        <Avatar variant="square" src={src} defaultSrc={DEFAULT_PROJECT_AVATAR_URL} alt="" />
+      </AvatarContainer>
+    </>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glitchdotcom/shared-components",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glitchdotcom/shared-components",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Shared components",
   "main": "build/main.js",
   "module": "build/module.js",


### PR DESCRIPTION
Previously, `<Avatar src={null} defaultSrc={fallbackImg} />` would flicker with the fallback image, and then go blank. I believe this is because:
- if an img src is a string, it will try to load the URL at that string and error if it fails; however, if src is nullish then it just shows nothing
- useEffect runs after mount, not just after updates, so the useEffect handler immediately overwrites the initial value of activeSrc
- the previous version of the useEffect handler did not have defaultSrc as a fallback value if src was falsy, so it was setting activeSrc to src's nullish value

With this PR, `<Avatar src={null} defaultSrc={fallbackImg} />` shows the fallback image consistently. I also added a story that demonstrates the defaultSrc behavior and verifies that the provided change works correctly.