### PR TITLE
Update domain when initial name changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.9] - 2020-05-06
+### Changed
+- `lib/editable-project-domain.js`: update domain when initialName changes
+
 ## [0.14.8] - 2020-05-05
 Add `sharedGalaxy` to icon set
 

--- a/lib/editable-project-domain.js
+++ b/lib/editable-project-domain.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { OptimisticTextInput } from './optimistic-inputs';
 import { CodeExample, PropsDefinition, Prop } from './story-utils';
@@ -15,6 +15,9 @@ import { Button } from './button';
 */
 export const EditableProjectDomain = ({ initialName, onChange, onBlur }) => {
   const [headingState, setHeadingState] = useState(initialName);
+  useEffect(() => {
+    setHeadingState(initialName);
+  }, [initialName]);
   const handleOnChange = async (newName) => {
     setHeadingState(newName);
     if (onChange) {
@@ -51,47 +54,50 @@ EditableProjectDomain.defaultProps = {
 export const StoryEditableProjectDomain = () => {
   const [mockError, setMockError] = useState(false);
   return (
-  <>
-    <p>The EditableProjectDomain Component is a souped up OptimisticTextInput designed for when users want to edit their project domain. As with all OptimisticTextInputs if an error is thrown in the onChange or onBlur, it'll show a default error state (right now that's a little firetruck). To test that out use the button below and then type.</p>
-    <PropsDefinition>
-      <Prop name="initialName">
-        The project domain as it is currently saved in state
-      </Prop>
-      <Prop name="onChange">
-        A callback function, which is called with the input's new value on change events. Should be used to persist changes everytime the user types (also potentially updating the url in the browser so as to more gracefully handle refreshes)
-      </Prop>
-      <Prop name="onBlur">
-        A callback function, which is called with the user navigates away from the input. Should be used to update state throughout the page globally (no need to cause global rerenders until we're ready)
-      </Prop>
-      <CodeExample>
-      {
-`<EditableProjectDomain 
+    <>
+      <p>
+        The EditableProjectDomain Component is a souped up OptimisticTextInput designed for when users want to edit their project domain. As with all
+        OptimisticTextInputs if an error is thrown in the onChange or onBlur, it'll show a default error state (right now that's a little firetruck).
+        To test that out use the button below and then type.
+      </p>
+      <PropsDefinition>
+        <Prop name="initialName">The project domain as it is currently saved in state</Prop>
+        <Prop name="onChange">
+          A callback function, which is called with the input's new value on change events. Should be used to persist changes everytime the user types
+          (also potentially updating the url in the browser so as to more gracefully handle refreshes)
+        </Prop>
+        <Prop name="onBlur">
+          A callback function, which is called with the user navigates away from the input. Should be used to update state throughout the page
+          globally (no need to cause global rerenders until we're ready)
+        </Prop>
+        <CodeExample>
+          {`<EditableProjectDomain 
   initialName="a-great-project-name" 
   onChange={() => console.log("saved to the backend")} 
   onBlur={(() => console.log("we're done here, update everywhere"))}
-/>`
-      }
-    </CodeExample>
-      <div style={{ marginBottom: "10px" }}>
-        <EditableProjectDomain 
-          initialName="a-great-project-name" 
-          onChange={() => {
-            setMockError(false);
-            if (mockError) {
-              const fakeError = new Error()
-              fakeError.response = {
-                data: {
-                  message: "That name is already taken, please try a different one"
-                }
+/>`}
+        </CodeExample>
+        <div style={{ marginBottom: '10px' }}>
+          <EditableProjectDomain
+            initialName="a-great-project-name"
+            onChange={() => {
+              setMockError(false);
+              if (mockError) {
+                const fakeError = new Error();
+                fakeError.response = {
+                  data: {
+                    message: 'That name is already taken, please try a different one',
+                  },
+                };
+                throw fakeError;
               }
-              throw fakeError
-            }
-            console.log("saved to the backend")
-          }} 
-          onBlur={(() => console.log("we're done here, update everywhere"))}
-        />
-      </div>
-      <Button onClick={() => setMockError(true)}>Click to trigger a fake error next time the user types</Button>
-    </PropsDefinition>
-  </>
-)};
+              console.log('saved to the backend');
+            }}
+            onBlur={() => console.log("we're done here, update everywhere")}
+          />
+        </div>
+        <Button onClick={() => setMockError(true)}>Click to trigger a fake error next time the user types</Button>
+      </PropsDefinition>
+    </>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glitchdotcom/shared-components",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glitchdotcom/shared-components",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "description": "Shared components",
   "main": "build/main.js",
   "module": "build/module.js",


### PR DESCRIPTION
EditableProjectDomain shared component does not "sync" -- i.e. when the domain in the header nav EditableProjectDomain changes, the domain on the page does not update, and vice versa. This PR fixes this behavior.