### PR TITLE
[ch16918] Add text-colored lightning bolt icon.

### DIFF
--- a/lib/icon.js
+++ b/lib/icon.js
@@ -187,6 +187,11 @@ const svgs = {
       <path d="M8,8 L56,56 M8,56 L56,8" stroke="currentColor" fill="none" strokeWidth="12" />
     </SVGBase>
   ),
+  textLightningBolt: (props) => (
+    <SVGBase viewBox="0 0 11 15" {...props}>
+      <path d="M0 8.44221L8.30935 0L4.7482 6.03015L11 5.80402L0.316547 15L5.46043 8.1407L0 8.44221Z" fill="currentColor"/>
+    </SVGBase>
+  ),
 };
 /* eslint-enable react/display-name */
 


### PR DESCRIPTION
Adds a text-color version of the lightning bolt icon. The [mockups](https://www.figma.com/file/rtQwLELjwY75LVljdBouz1/052720_UptimeLimits_MI?node-id=590%3A489) for the app dashboard show a cyan-colored lightning bolt icon in the static app badge:

![Screen Shot 2020-06-17 at 12 09 16 AM](https://user-images.githubusercontent.com/193106/84866644-d5ca2380-b02e-11ea-9769-c0b76018dc32.png)

Since the existing one cannot be recolored, I figured adding a full-vector version was best.

![Screen Shot 2020-06-17 at 12 08 10 AM](https://user-images.githubusercontent.com/193106/84866693-ebd7e400-b02e-11ea-874a-9c9057346eba.png)

I don't have an npm account linked to the org, so help with deploying this after merging would be appreciated. Thank you!