### PR TITLE
add banner variant to Overlay

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -3,8 +3,7 @@ import styled, { css } from 'styled-components';
 import { IconButton } from './icon-button';
 import { CodeExample, PropsDefinition, Prop } from './story-utils';
 
-const variants = {
-  // variants for Section
+const sectionVariants = {
   info: css`
     color: var(--colors-primary);
     background-color: var(--colors-secondaryBackground);
@@ -20,18 +19,23 @@ const variants = {
     background-color: var(--colors-warning-background);
     border-top: 1px solid var(--colors-border);
   `,
-  // default variant for title
-  title: css`
-    color: var(--colors-primary);
-    background-color: var(--colors-secondaryBackground);
-  `,
-  // variants for Overlay Banner
   banner: css`
     color: var(--colors-primary);
     background-color: var(--colors-background);
   `,
-  alignright: css`
+  alignrightbanner: css`
     text-align: right;
+  `,
+};
+
+const titleVariants = {
+  normal: css`
+    color: var(--colors-primary);
+    background-color: var(--colors-secondaryBackground);
+  `,
+  banner: css`
+    color: var(--colors-primary);
+    background-color: var(--colors-background);
   `,
 };
 
@@ -42,7 +46,7 @@ const TitleWrap = styled.header`
   align-items: baseline;
   font-size: var(--fontSizes-small);
   padding: var(--space-1);
-  ${({ variant }) => variants[variant]};
+  ${({ variant }) => titleVariants[variant]};
 `;
 
 const TitleContent = styled.h2`
@@ -54,7 +58,6 @@ const TitleContent = styled.h2`
 
 TitleWrap.defaultProps = {
   variant: 'normal',
-  collapsed: false,
 };
 
 export const Title = ({ children, onBack, onBackRef, variant, onClose, onCloseRef, ...props }) => (
@@ -68,7 +71,7 @@ export const Title = ({ children, onBack, onBackRef, variant, onClose, onCloseRe
 const Section = styled.section`
   padding: var(--space-1);
   margin: 0;
-  ${({ variant }) => variants[variant]};
+  ${({ variant }) => sectionVariants[variant]};
   &:first-child {
     border-top: none;
   }

--- a/lib/block.js
+++ b/lib/block.js
@@ -19,11 +19,14 @@ const sectionVariants = {
     background-color: var(--colors-warning-background);
     border-top: 1px solid var(--colors-border);
   `,
-  banner: css`
+  infobanner: css`
     color: var(--colors-primary);
     background-color: var(--colors-background);
+    font-size: 14px;
+    margin-top: 6px;
+    margin-bottom: 24px;
   `,
-  alignrightbanner: css`
+  actionsbanner: css`
     text-align: right;
   `,
 };
@@ -32,10 +35,21 @@ const titleVariants = {
   normal: css`
     color: var(--colors-primary);
     background-color: var(--colors-secondaryBackground);
+    font-size: var(--fontSizes-small);
   `,
   banner: css`
     color: var(--colors-primary);
     background-color: var(--colors-background);
+    font-size: 14px;
+  `,
+};
+
+const titleContentVariants = {
+  normal: css`
+    font-size: var(--fontSizes-small);
+  `,
+  banner: css`
+    font-size: 16px;
   `,
 };
 
@@ -44,7 +58,6 @@ const titleVariants = {
 const TitleWrap = styled.header`
   display: flex;
   align-items: baseline;
-  font-size: var(--fontSizes-small);
   padding: var(--space-1);
   ${({ variant }) => titleVariants[variant]};
 `;
@@ -53,17 +66,21 @@ const TitleContent = styled.h2`
   flex: 1 1 auto;
   margin: 0;
   padding: 0;
-  font-size: var(--fontSizes-small);
+  ${({ variant }) => titleContentVariants[variant]};
 `;
 
 TitleWrap.defaultProps = {
   variant: 'normal',
 };
 
+TitleContent.defaultProps = {
+  variant: 'normal',
+};
+
 export const Title = ({ children, onBack, onBackRef, variant, onClose, onCloseRef, ...props }) => (
   <TitleWrap data-module="Title" variant={variant} {...props}>
     {onBack && <IconButton onClick={onBack} ref={onBackRef} icon="chevronLeft" label="Back" />}
-    <TitleContent>{children}</TitleContent>
+    <TitleContent variant={variant}>{children}</TitleContent>
     {onClose && <IconButton onClick={onClose} ref={onCloseRef} icon="x" label="Close" />}
   </TitleWrap>
 );

--- a/lib/block.js
+++ b/lib/block.js
@@ -3,6 +3,38 @@ import styled, { css } from 'styled-components';
 import { IconButton } from './icon-button';
 import { CodeExample, PropsDefinition, Prop } from './story-utils';
 
+const variants = {
+  // variants for Section
+  info: css`
+    color: var(--colors-primary);
+    background-color: var(--colors-secondaryBackground);
+    border-top: 1px solid var(--colors-border);
+  `,
+  actions: css`
+    color: var(--colors-primary);
+    background-color: var(--colors-background);
+    border-top: 1px solid var(--colors-border);
+  `,
+  warning: css`
+    color: var(--colors-warning-text);
+    background-color: var(--colors-warning-background);
+    border-top: 1px solid var(--colors-border);
+  `,
+  // default variant for title
+  title: css`
+    color: var(--colors-primary);
+    background-color: var(--colors-secondaryBackground);
+  `,
+  // variants for Overlay Banner
+  banner: css`
+    color: var(--colors-primary);
+    background-color: var(--colors-background);
+  `,
+  alignright: css`
+    text-align: right;
+  `,
+};
+
 // used in popovers and overlays
 
 const TitleWrap = styled.header`
@@ -10,8 +42,9 @@ const TitleWrap = styled.header`
   align-items: baseline;
   font-size: var(--fontSizes-small);
   padding: var(--space-1);
-  background-color: var(--colors-secondaryBackground);
+  ${({ variant }) => variants[variant]};
 `;
+
 const TitleContent = styled.h2`
   flex: 1 1 auto;
   margin: 0;
@@ -19,34 +52,23 @@ const TitleContent = styled.h2`
   font-size: var(--fontSizes-small);
 `;
 
-export const Title = ({ children, onBack, onBackRef, onClose, onCloseRef, ...props }) => (
-  <TitleWrap data-module="Title" {...props}>
+TitleWrap.defaultProps = {
+  variant: 'normal',
+  collapsed: false,
+};
+
+export const Title = ({ children, onBack, onBackRef, variant, onClose, onCloseRef, ...props }) => (
+  <TitleWrap data-module="Title" variant={variant} {...props}>
     {onBack && <IconButton onClick={onBack} ref={onBackRef} icon="chevronLeft" label="Back" />}
     <TitleContent>{children}</TitleContent>
     {onClose && <IconButton onClick={onClose} ref={onCloseRef} icon="x" label="Close" />}
   </TitleWrap>
 );
 
-const variants = {
-  info: css`
-    color: var(--colors-primary);
-    background-color: var(--colors-secondaryBackground);
-  `,
-  actions: css`
-    color: var(--colors-primary);
-    background-color: var(--colors-background);
-  `,
-  warning: css`
-    color: var(--colors-warning-text);
-    background-color: var(--colors-warning-background);
-  `,
-};
-
 const Section = styled.section`
   padding: var(--space-1);
   margin: 0;
   ${({ variant }) => variants[variant]};
-  border-top: 1px solid var(--colors-border);
   &:first-child {
     border-top: none;
   }

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { createGlobalStyle } from 'styled-components';
+import styled, { createGlobalStyle, css } from 'styled-components';
 import { Button } from './button';
 import { Title, Info, Actions } from './block';
 import { useEscape, useFocusTrap } from './keyboard-navigation';
@@ -28,21 +28,34 @@ const OverlayContent = styled.dialog.attrs(() => ({
   open: true,
   'aria-modal': true,
 }))`
-  position: relative;
-  width: 100%;
-  max-width: 640px;
-  margin: 0;
-  padding: 0;
-
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   background-color: var(--colors-background);
   color: var(--colors-primary);
-  font-size: var(--fontSizes-small);
-  border: 2px var(--colors-primary) solid;
   border-radius: var(--rounded);
+  font-size: var(--fontSizes-small);
   box-shadow: var(--popShadow);
   overflow: auto;
+  padding: 0;
+  ${({ variant }) => variants[variant]};
 `;
+
+const variants = {
+  normal: css`
+    position: relative;
+    border: 2px var(--colors-primary) solid;
+    margin: 0;
+    width: 100%;
+    max-width: 640px;
+  `,
+  banner: css`
+    position: absolute;
+    border: 1px var(--colors-border) solid;
+    margin: 0 auto;
+    padding: 20px;
+    top: 0px;
+    max-width: 500px;
+  `,
+};
 
 const FixedBodyStyle = createGlobalStyle`
   body {
@@ -80,8 +93,12 @@ export const mergeRefs = (...refs) => (el) => {
   }
 };
 
+OverlayContent.defaultProps = {
+  variant: 'normal',
+  collapsed: false,
+};
 // https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal
-export const Overlay = ({ open, onClose, children, contentProps, ...props }) => {
+export const Overlay = ({ open, onClose, children, variant, contentProps, ...props }) => {
   useEscape(open, onClose);
   const { first, last } = useFocusTrap();
   const focusedOnMount = useFocusOnMount(open);
@@ -97,15 +114,19 @@ export const Overlay = ({ open, onClose, children, contentProps, ...props }) => 
   return (
     <OverlayWrap data-module="Overlay" onClick={onClickBackground} {...props}>
       <FixedBody />
-      <OverlayContent {...contentProps}>{children({ onClose, first, last, focusedOnMount })}</OverlayContent>
+      <OverlayContent variant={variant} {...contentProps}>
+        {children({ onClose, first, last, focusedOnMount })}
+      </OverlayContent>
     </OverlayWrap>
   );
 };
+
 Overlay.propTypes = {
   open: PropTypes.bool.isRequired,
   children: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   contentProps: PropTypes.object,
+  variant: PropTypes.oneOf(Object.keys(variants)),
 };
 
 export const useOverlay = () => {
@@ -124,7 +145,10 @@ export const StoryOverlay = () => {
 
   return (
     <>
-      <p>The Overlay component renders an accessible modal. See <a href="#Story_Blocks_for_Overlay_and_Popover_content">blocks to use with Overlays</a>.</p>
+      <p>
+        The Overlay component renders an accessible modal. See <a href="#Story_Blocks_for_Overlay_and_Popover_content">blocks to use with Overlays</a>
+        .
+      </p>
       <CodeExample>
         {code`
           <Overlay open={open} onClose={onClose}>

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -136,21 +136,19 @@ const ButtonContainer = styled.div`
 `;
 
 export const useOverlay = () => {
-  const [openNormal, setOpenNormal] = React.useState(false);
-  const [openBanner, setOpenBanner] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
   const toggleRef = React.useRef();
-  const onOpenNormal = () => setOpenNormal(true);
-  const onOpenBanner = () => setOpenBanner(true);
+  const onOpen = () => setOpen(true);
   const onClose = () => {
-    setOpenNormal(false);
-    setOpenBanner(false);
+    setOpen(false);
     toggleRef.current.focus();
   };
-  return { openNormal, onOpenNormal, openBanner, onOpenBanner, onClose, toggleRef };
+  return { open, onOpen, onClose, toggleRef };
 };
 
 export const StoryOverlay = () => {
-  const { openNormal, onOpenNormal, openBanner, onOpenBanner, onClose, toggleRef } = useOverlay();
+  const normalOverlay = useOverlay();
+  const bannerOverlay = useOverlay();
 
   return (
     <>
@@ -179,6 +177,7 @@ export const StoryOverlay = () => {
         <Prop name="onClose" required>
           A callback function called to close the overlay.
         </Prop>
+        <Prop name="variant">The overlay's visual style: "normal" (default) or "banner."</Prop>
         <Prop name="children" required>
           A render prop, which passes in an object with the following properties:
           <dl>
@@ -201,15 +200,15 @@ export const StoryOverlay = () => {
         </Prop>
       </PropsDefinition>
       <ButtonContainer>
-        <Button onClick={onOpenNormal} ref={toggleRef}>
+        <Button onClick={normalOverlay.onOpen} ref={normalOverlay.toggleRef}>
           Show Normal Overlay
         </Button>
-        <Button onClick={onOpenBanner} ref={toggleRef}>
+        <Button onClick={bannerOverlay.onOpen} ref={bannerOverlay.toggleRef}>
           Show Banner Overlay
         </Button>
       </ButtonContainer>
       {/* Normal Overlay */}
-      <Overlay open={openNormal} onClose={onClose}>
+      <Overlay open={normalOverlay.open} onClose={normalOverlay.onClose}>
         {({ onClose, first, last, focusedOnMount }) => (
           <>
             <Title onClose={onClose} onCloseRef={first}>
@@ -239,7 +238,7 @@ export const StoryOverlay = () => {
         )}
       </Overlay>
       {/* Banner Overlay */}
-      <Overlay open={openBanner} variant={'banner'} onClose={onClose}>
+      <Overlay open={bannerOverlay.open} variant={'banner'} onClose={bannerOverlay.onClose}>
         {({ onClose, first, last, focusedOnMount }) => (
           <>
             <Title variant={'banner'} onCloseRef={first}>

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -32,7 +32,6 @@ const OverlayContent = styled.dialog.attrs(() => ({
   background-color: var(--colors-background);
   color: var(--colors-primary);
   border-radius: var(--rounded);
-  font-size: var(--fontSizes-small);
   overflow: auto;
   padding: 0;
   ${({ variant }) => variants[variant]};
@@ -43,6 +42,7 @@ const variants = {
     position: relative;
     border: 2px var(--colors-primary) solid;
     box-shadow: var(--popShadow);
+    font-size: var(--fontSizes-small);
     margin: 0;
     width: 100%;
     max-width: 640px;
@@ -51,7 +51,7 @@ const variants = {
     position: absolute;
     border: 1px var(--colors-border) solid;
     margin: 0 auto;
-    padding: 20px;
+    padding: 16px;
     top: 0px;
     max-width: 500px;
   `,
@@ -129,7 +129,7 @@ Overlay.propTypes = {
 };
 
 const ButtonContainer = styled.div`
-  margin: var(--space-1) auto;
+  margin: 0 auto;
   & > * {
     margin: 0 var(--space-1) var(--space-1) 0;
   }
@@ -243,20 +243,14 @@ export const StoryOverlay = () => {
         {({ onClose, first, last, focusedOnMount }) => (
           <>
             <Title variant={'banner'} onCloseRef={first}>
-              Example Overlay
+              Example Banner Overlay
             </Title>
-            <Info variant={'banner'}>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquet faucibus augue quis laoreet. Ut cursus venenatis nisl, ut
-                ullamcorper lectus. Nunc nec lacus sem. Donec nulla arcu, dignissim id feugiat id, varius nec leo. Donec sit amet ultrices magna.
-                Proin quis metus quis metus vulputate posuere et eget quam. Ut nunc ante, convallis ac ornare nec, porttitor id lectus. Suspendisse
-                orci urna, placerat a pulvinar at, porta quis ante. Suspendisse eleifend mauris in tincidunt hendrerit. Praesent sagittis dui eu metus
-                consectetur, in sagittis dui euismod. Aenean massa libero, pellentesque eu metus ut, varius ultricies orci. Vestibulum sit amet magna
-                aliquam, semper tortor vitae, vehicula eros. Aliquam quis elementum dui. Integer in nisl quis est aliquet commodo vitae in eros.
-                Integer et metus dapibus sem viverra pretium. Quisque et elit nisl.
-              </p>
+            <Info variant={'infobanner'}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquet faucibus augue quis laoreet. Ut cursus venenatis nisl, ut
+              ullamcorper lectus. Nunc nec lacus sem. Donec nulla arcu, dignissim id feugiat id, varius nec leo. Donec sit amet ultrices magna. Proin
+              quis metus quis metus vulputate posuere et eget quam. Ut nunc ante, convallis ac ornare nec, porttitor id lectus.
             </Info>
-            <Actions variant={'alignrightbanner'}>
+            <Actions variant={'actionsbanner'}>
               <ButtonContainer>
                 <Button ref={focusedOnMount} onClick={onClose}>
                   Primary Action

--- a/lib/overlay.js
+++ b/lib/overlay.js
@@ -33,7 +33,6 @@ const OverlayContent = styled.dialog.attrs(() => ({
   color: var(--colors-primary);
   border-radius: var(--rounded);
   font-size: var(--fontSizes-small);
-  box-shadow: var(--popShadow);
   overflow: auto;
   padding: 0;
   ${({ variant }) => variants[variant]};
@@ -43,6 +42,7 @@ const variants = {
   normal: css`
     position: relative;
     border: 2px var(--colors-primary) solid;
+    box-shadow: var(--popShadow);
     margin: 0;
     width: 100%;
     max-width: 640px;
@@ -95,7 +95,6 @@ export const mergeRefs = (...refs) => (el) => {
 
 OverlayContent.defaultProps = {
   variant: 'normal',
-  collapsed: false,
 };
 // https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal
 export const Overlay = ({ open, onClose, children, variant, contentProps, ...props }) => {
@@ -129,19 +128,29 @@ Overlay.propTypes = {
   variant: PropTypes.oneOf(Object.keys(variants)),
 };
 
+const ButtonContainer = styled.div`
+  margin: var(--space-1) auto;
+  & > * {
+    margin: 0 var(--space-1) var(--space-1) 0;
+  }
+`;
+
 export const useOverlay = () => {
-  const [open, setOpen] = React.useState(false);
+  const [openNormal, setOpenNormal] = React.useState(false);
+  const [openBanner, setOpenBanner] = React.useState(false);
   const toggleRef = React.useRef();
-  const onOpen = () => setOpen(true);
+  const onOpenNormal = () => setOpenNormal(true);
+  const onOpenBanner = () => setOpenBanner(true);
   const onClose = () => {
-    setOpen(false);
+    setOpenNormal(false);
+    setOpenBanner(false);
     toggleRef.current.focus();
   };
-  return { open, onOpen, onClose, toggleRef };
+  return { openNormal, onOpenNormal, openBanner, onOpenBanner, onClose, toggleRef };
 };
 
 export const StoryOverlay = () => {
-  const { open, onOpen, onClose, toggleRef } = useOverlay();
+  const { openNormal, onOpenNormal, openBanner, onOpenBanner, onClose, toggleRef } = useOverlay();
 
   return (
     <>
@@ -191,10 +200,16 @@ export const StoryOverlay = () => {
           </p>
         </Prop>
       </PropsDefinition>
-      <Button onClick={onOpen} ref={toggleRef}>
-        Show Overlay
-      </Button>
-      <Overlay open={open} onClose={onClose}>
+      <ButtonContainer>
+        <Button onClick={onOpenNormal} ref={toggleRef}>
+          Show Normal Overlay
+        </Button>
+        <Button onClick={onOpenBanner} ref={toggleRef}>
+          Show Banner Overlay
+        </Button>
+      </ButtonContainer>
+      {/* Normal Overlay */}
+      <Overlay open={openNormal} onClose={onClose}>
         {({ onClose, first, last, focusedOnMount }) => (
           <>
             <Title onClose={onClose} onCloseRef={first}>
@@ -219,6 +234,38 @@ export const StoryOverlay = () => {
               <Button ref={last} onClick={onClose} variant="secondary">
                 Secondary Action
               </Button>
+            </Actions>
+          </>
+        )}
+      </Overlay>
+      {/* Banner Overlay */}
+      <Overlay open={openBanner} variant={'banner'} onClose={onClose}>
+        {({ onClose, first, last, focusedOnMount }) => (
+          <>
+            <Title variant={'banner'} onCloseRef={first}>
+              Example Overlay
+            </Title>
+            <Info variant={'banner'}>
+              <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquet faucibus augue quis laoreet. Ut cursus venenatis nisl, ut
+                ullamcorper lectus. Nunc nec lacus sem. Donec nulla arcu, dignissim id feugiat id, varius nec leo. Donec sit amet ultrices magna.
+                Proin quis metus quis metus vulputate posuere et eget quam. Ut nunc ante, convallis ac ornare nec, porttitor id lectus. Suspendisse
+                orci urna, placerat a pulvinar at, porta quis ante. Suspendisse eleifend mauris in tincidunt hendrerit. Praesent sagittis dui eu metus
+                consectetur, in sagittis dui euismod. Aenean massa libero, pellentesque eu metus ut, varius ultricies orci. Vestibulum sit amet magna
+                aliquam, semper tortor vitae, vehicula eros. Aliquam quis elementum dui. Integer in nisl quis est aliquet commodo vitae in eros.
+                Integer et metus dapibus sem viverra pretium. Quisque et elit nisl.
+              </p>
+            </Info>
+            <Actions variant={'alignrightbanner'}>
+              <ButtonContainer>
+                <Button ref={focusedOnMount} onClick={onClose}>
+                  Primary Action
+                </Button>
+                &nbsp;
+                <Button ref={last} onClick={onClose}>
+                  Secondary Action
+                </Button>
+              </ButtonContainer>
             </Actions>
           </>
         )}


### PR DESCRIPTION
This PR adds a banner variant for Overlay. The goal is to create an Overlay option that looks close to the one in this design spec: https://www.figma.com/file/LLBMwcB37R4fQrn7kgZKUi/061820_PrivateApps_MI%2BKAC?node-id=34%3A0

This introduces new variants in `block.js` for this Overlay banner, specifically. I commented above the relevant banners to hopefully make this clearer. 

How to Test
1. Go to `overlay.js`
2. Add `variant={'banner'}` to the `Overlay`, `Title,` and `Info` components
3. Add `variant={'alignright'}` to the `Actions` component
4. When you open an overlay, it should look like the overlay in the attached screenshot: 

<img width="1295" alt="Screen Shot 2020-07-09 at 8 43 58 PM" src="https://user-images.githubusercontent.com/32645629/87104267-66a6b000-c225-11ea-9a6c-6c3ebd8b565d.png">
5. Test in dark mode!