### PR TITLE
Don't show the Results List if there's nothing to show yet

### DIFF
--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -173,11 +173,6 @@ const resultOptions = [
   { id: 3, domain: 'peppered-deltadromeus', description: 'this is a remix of shared components', private: false },
 ];
 
-const resultOptions2 = [
-  { id: 1, domain: 'power-passenger', description: 'take 2 on glitch component library', private: false },
-  { id: 2, domain: 'fan-coal', description: 'this one is yellow because we are pretending it is a private project', private: true },
-  { id: 3, domain: 'peppered-deltadromeus', description: 'this is a remix of shared components', private: false },
-];
 
 const Container = styled.div`
   width: 20rem;
@@ -235,7 +230,7 @@ export const StoryResultsList = () => {
         </Prop>
       </PropsDefinition>
       <Container>
-        <ResultsList value={value} onChange={(id) => onChange(id)} options={resultOptions2}>
+        <ResultsList value={value} onChange={(id) => onChange(id)} options={resultOptions}>
           {({ item, buttonProps }) => (
             <ResultItem as="a" href={`https://glitch.com/~${item.domain}`} isPrivate={item.private} {...buttonProps}>
               <ResultInfo>

--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -54,7 +54,7 @@ export const ResultsList = ({ scroll, value, options, onChange, onKeyDown, child
 
   return (
     <ScrollContainer data-module="ResultsList" scroll={scroll} {...props}>
-      <ResultsListContainer>
+      {options.length > 0 && <ResultsListContainer>
         {options.map((item, i) => (
           <ResultItemWrap key={item.id}>
             {children({
@@ -69,7 +69,7 @@ export const ResultsList = ({ scroll, value, options, onChange, onKeyDown, child
             })}
           </ResultItemWrap>
         ))}
-      </ResultsListContainer>
+      </ResultsListContainer>}
     </ScrollContainer>
   );
 };
@@ -173,6 +173,12 @@ const resultOptions = [
   { id: 3, domain: 'peppered-deltadromeus', description: 'this is a remix of shared components', private: false },
 ];
 
+const resultOptions2 = [
+  { id: 1, domain: 'power-passenger', description: 'take 2 on glitch component library', private: false },
+  { id: 2, domain: 'fan-coal', description: 'this one is yellow because we are pretending it is a private project', private: true },
+  { id: 3, domain: 'peppered-deltadromeus', description: 'this is a remix of shared components', private: false },
+];
+
 const Container = styled.div`
   width: 20rem;
 `;
@@ -229,7 +235,7 @@ export const StoryResultsList = () => {
         </Prop>
       </PropsDefinition>
       <Container>
-        <ResultsList value={value} onChange={(id) => onChange(id)} options={resultOptions}>
+        <ResultsList value={value} onChange={(id) => onChange(id)} options={resultOptions2}>
           {({ item, buttonProps }) => (
             <ResultItem as="a" href={`https://glitch.com/~${item.domain}`} isPrivate={item.private} {...buttonProps}>
               <ResultInfo>

--- a/lib/search-results.js
+++ b/lib/search-results.js
@@ -86,6 +86,7 @@ const resultOptions = [
 export const StorySearchResults = () => {
   const [query, setQuery] = React.useState('');
   const filteredOptions = React.useMemo(() => {
+    if (!query) {return []}
     const options = resultOptions.filter((opt) => opt.domain.includes(query.trim()));
     return options;
   }, [query]);


### PR DESCRIPTION
This is causing a blank box to appear under the search box when you click into it; this PR fixes it.

Before:
<img width="280" alt="Screenshot 2020-08-12 at 12 00 37 PM" src="https://user-images.githubusercontent.com/9853740/90002823-7d607c80-dc93-11ea-94a7-c5422ee35ead.png">

After:
<img width="917" alt="Screenshot 2020-08-12 at 12 00 25 PM" src="https://user-images.githubusercontent.com/9853740/90002828-7df91300-dc93-11ea-9a6c-ac4c026539de.png">

See Search Results in `obtainable-excessive-salary.glitch.me` for a demo.