### PR TITLE
Don't propagate notification close button clicks

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -110,7 +110,13 @@ export const Notification = ({ message, live, children, variant, timeout, onClos
     >
       <NotificationContent>{children || message}</NotificationContent>
       {onClose && (
-        <CloseButton onClick={() => setClosing(true)} aria-label="Dismiss notification">
+        <CloseButton
+          onClick={(event) => {
+            event.stopPropagation;
+            setClosing(true);
+          }}
+          aria-label="Dismiss notification"
+        >
           <Icon icon="x" style={{ color: 'inherit' }} />
         </CloseButton>
       )}
@@ -154,8 +160,8 @@ export const StoryNotification = () => (
         <code>createNotification</code> callback. If no value is provided, the notification will not render a close button.
       </Prop>
       <Prop name="persistent">
-        A boolean value. If true, any timeout value is ignored and the Notification will remain until removed either programmatically or by a 
-        user action. If no value is provided, the Notification will be removed after the timeout period.
+        A boolean value. If true, any timeout value is ignored and the Notification will remain until removed either programmatically or by a user
+        action. If no value is provided, the Notification will be removed after the timeout period.
       </Prop>
     </PropsDefinition>
     <p></p>


### PR DESCRIPTION
Currently, a click on the close button of a notification propagates through the DOM, resulting in things like overlays closing. This PR addresses that issue.