### PR TITLE
fix tooltip

### DIFF
--- a/lib/tooltip.js
+++ b/lib/tooltip.js
@@ -251,7 +251,7 @@ const TooltipBase = styled.div`
 `;
 
 const InvisibleHoverTarget = styled.span`
-  position: absolute;
+  position: relative;
   left: 0;
   display: block;
   width: 100%;


### PR DESCRIPTION
This is a very very small change to prevent the `InvisibleHoverTarget` within `TooltipContainer` from covering up the elements below it.

@glitchdotcom/product-eng 

[19522](https://app.clubhouse.io/glitch/stories/space/17257/p1-private-project-blockers)