### PR TITLE
Update Styling to SearchResults component

### DIFF
--- a/lib/results-list.js
+++ b/lib/results-list.js
@@ -19,7 +19,7 @@ const ScrollContainer = styled.div`
 
 const ResultsListContainer = styled.ul`
   margin: 0;
-  padding: var(--space-1);
+  padding: 0;
   list-style-type: none;
 `;
 
@@ -92,12 +92,13 @@ ResultsList.defaultProps = {
 
 export const ResultInfo = styled.span.attrs(() => ({ 'data-module': 'ResultInfo' }))`
   display: block;
-  padding-left: var(--space-2);
+  padding: var(--space-1) var(--space-2);
   width: 100%;
 `;
 
 export const ResultNameBase = styled.span.attrs(() => ({ 'data-module': 'ResultName' }))`
-  font-size: var(--fontSizes-small);
+  font-size: 14px;
+  line-height: 160%;
 `;
 
 const NameIcon = styled(Icon)`
@@ -117,9 +118,8 @@ export const ResultDescription = styled.span.attrs(() => ({ 'data-module': 'Resu
   color: var(--colors-secondary);
   word-break: break-word;
   font-family: var(--fonts-mono);
-  font-size: var(--fontSizes-tiny);
-  line-height: 1.5;
-  padding-top: var(--space-1);
+  font-size: 13px;
+  line-height: 22px;
 `;
 
 // This is defined as a <span>, but is actually <UnstyledButton> by default,
@@ -131,11 +131,11 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
   width: 100%;
   font-size: var(--fontSizes-normal);
   color: var(--colors-primary);
-  background-color: ${props => props.isPrivate ? "var(--colors-private-background);" : "var(--colors-background);"};
+  background-color: ${(props) => (props.isPrivate ? 'var(--colors-private-background);' : 'var(--colors-background);')};
   position: relative;
-  padding: var(--space-1);
+  padding: 0;
   text-decoration: none;
-  margin: var(--space-1) 0;
+  margin: 0;
 
   &:focus,
   button:focus &,
@@ -143,23 +143,33 @@ export const ResultItem = styled.span.attrs(() => ({ 'data-module': 'ResultItem'
     box-shadow: 0 0 0 1px white, 0 0 0 3px var(--colors-focused);
     outline-color: transparent;
     color: var(--colors-selected-text);
-    background-color: var(--colors-selected-background);
+    background-color: #5a78ff;
+    color: black;
 
     ${ResultDescription} {
-      color: var(--colors-selected-secondary);
+      color: black;
     }
   }
   &:hover,
   button:hover &,
   a:hover & {
-    background-color: var(--colors-secondaryBackground);
+    color: black;
+    background-color: #5a78ff;
     text-decoration: none;
+
+    ${ResultDescription} {
+      color: black;
+    }
   }
   &:active,
   button:active &,
   a:active & {
-    color: var(--colors-selected-text);
-    background-color: var(--colors-selected-background);
+    color: black;
+    background-color: #5a78ff;
+
+    ${ResultDescription} {
+      color: black;
+    }
   }
 `;
 


### PR DESCRIPTION
I updated some of the styling for the `SearchResults` component to match the Figma for the new private project overlay: https://www.figma.com/file/LLBMwcB37R4fQrn7kgZKUi/061820_PrivateProjects_MI%2BKAC?node-id=585%3A643

Some things to note/outstanding questions:

- In the Figma, the text on hover and focus is white. I chatted with @iuloshi and she suggested making it black for accessibility reasons, and that's what's reflected in this PR.
- Will we run into issues with the padding when we put user avatars next to the result item names and description?
- The result item description text looks like it's a little bigger than the result item name, but I copied over the font-size and line height from the Figma. Let me know if I should adjust accordingly or leave as is.


Original search results list
<img width="351" alt="original search results list" src="https://user-images.githubusercontent.com/32645629/96303981-5727c780-0fc9-11eb-8518-43648b886c48.png">

New search results list. The blue results in the screenshots are the ones being hovered on!

<img width="359" alt="new results list light mode" src="https://user-images.githubusercontent.com/32645629/96303982-57c05e00-0fc9-11eb-96e4-2f27e9e08a45.png">

It also looks like that white text on yellow isn't very accessible either — I can change that, or leave it since we don't use it anywhere and we'll be changing the shared component library anyway. 

<img width="352" alt="new results list dark mode" src="https://user-images.githubusercontent.com/32645629/96303983-57c05e00-0fc9-11eb-9a31-3477ae7fbe67.png">
