### PR TITLE
No longer specify the font-family in LocalStyle

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -42,7 +42,6 @@ export const RootStyle = createGlobalStyle`
 
 export const LocalStyle = styled.div`
   ${setThemeVars};
-  font-family: var(--fonts-sans);
   font-size: 100%;
   color: var(--colors-primary);
   --local-colors-secondary: var(--colors-secondary);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.22.0--canary.138.56f33e7.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @glitchdotcom/shared-components@0.22.0--canary.138.56f33e7.0
  # or 
  yarn add @glitchdotcom/shared-components@0.22.0--canary.138.56f33e7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
