### PR TITLE
Add a folder icon to icon.js

### DIFF
--- a/lib/icon.js
+++ b/lib/icon.js
@@ -311,6 +311,8 @@ const icons = {
     'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f692.svg',
   fishingPole:
     'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f3a3.svg',
+  folder:
+    'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f4c1.svg',
   framedPicture:
     'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f5bc.svg',
   gift:


### PR DESCRIPTION
We didn't have a folder icon O_o
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.22.6--canary.155.3c568e5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @glitchdotcom/shared-components@0.22.6--canary.155.3c568e5.0
  # or 
  yarn add @glitchdotcom/shared-components@0.22.6--canary.155.3c568e5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
